### PR TITLE
Refactor iptables engine for predictable output

### DIFF
--- a/fwsimple/constants.py
+++ b/fwsimple/constants.py
@@ -1,5 +1,5 @@
 """ Data contains all the constants """
-from typing import Dict, TYPE_CHECKING
+from typing import Dict, TYPE_CHECKING, List
 
 
 if TYPE_CHECKING:
@@ -38,6 +38,12 @@ BASIC_IP6TABLES_INIT = [
 # fmt: on
 
 DIRECTION: Dict["TrafficDirection", str] = {"in": "IN", "out": "OUT", "forward": "FWD"}
+# ORDERED_DIRECTIONS defines a fixed sequence for iterating over traffic directions.
+# This is used in engines to ensure that processing (e.g., for default policies
+# or zone chain creation) occurs in a predictable, deterministic order.
+# Relying on dictionary key order (from DIRECTION) can lead to inconsistencies
+# across different Python versions or implementations.
+ORDERED_DIRECTIONS: List[str] = ["in", "out", "forward"]
 
 EXEC_IPTABLES = 1
 EXEC_PF = 2

--- a/fwsimple/engines/__init__.py
+++ b/fwsimple/engines/__init__.py
@@ -81,8 +81,10 @@ class BaseEngine:
         for zone in self.firewall.zones:
             yield from self.zone_close(zone)
 
-        # Set default policies
-        for direction in fwsimple.constants.DIRECTION:
+        # Set default policies.
+        # Iterate in fixed order (see ORDERED_DIRECTIONS in constants.py)
+        # for predictable default policy application.
+        for direction in fwsimple.constants.ORDERED_DIRECTIONS:
             policy = self.firewall.get_default_policy(direction)
             yield from self.set_default_policy(direction, policy)
 

--- a/fwsimple/engines/iptables.py
+++ b/fwsimple/engines/iptables.py
@@ -43,7 +43,8 @@ class Engine(BaseEngine):
     #
     def zone_create(self, zone: "Zone") -> Iterable[List[str]]:
         """Create the zones for iptable and ip6tables"""
-        for direction in constants.DIRECTION:
+        # Iterate in fixed order for predictable chain creation.
+        for direction in constants.ORDERED_DIRECTIONS:
             cmd = ["-N", "%s_%s" % (constants.DIRECTION[direction], zone.name)]
             yield from self.__iptables(cmd)
 
@@ -51,7 +52,8 @@ class Engine(BaseEngine):
         self, expression: "ZoneExpression"
     ) -> Iterable[List[str]]:
         """Create expressions for the zones based on interface and optional source"""
-        for direction in constants.DIRECTION:
+        # Iterate in fixed order for predictable rule generation.
+        for direction in constants.ORDERED_DIRECTIONS:
             cmd = ["-A", constants.IPTABLES_DIRECTION[direction]]
             cmd += ["-m", "comment", "--comment", "Zone %s" % expression._zone.name]
 
@@ -74,7 +76,8 @@ class Engine(BaseEngine):
 
     def zone_close(self, zone: "Zone") -> Iterable[List[str]]:
         """Finish up the zones in iptables and ip6tables"""
-        for direction in constants.DIRECTION:
+        # Iterate in fixed order for predictable chain modification.
+        for direction in constants.ORDERED_DIRECTIONS:
             cmd = ["-A", "%s_%s" % (constants.DIRECTION[direction], zone.name)]
             cmd += ["-j", "RETURN"]
             yield from self.__iptables(cmd)

--- a/fwsimple/zone.py
+++ b/fwsimple/zone.py
@@ -98,7 +98,10 @@ class ZoneExpression(lib.FirewallExecution):
 
         return "<ZoneExpression(%s)>" % myrepr
 
-    # Sorting
+    # Sorting methods: __eq__, __ne__, and __lt__ are implemented to allow
+    # ZoneExpression objects to be sorted. This is crucial for ensuring
+    # a deterministic order when generating firewall rules, contributing to
+    # predictable firewall behavior. __lt__ defines the primary sorting logic.
     def __eq__(self, other: object) -> bool:
         if isinstance(other, ZoneExpression):
             return (self.interface == other.interface) and (self.source == other.source)
@@ -109,21 +112,95 @@ class ZoneExpression(lib.FirewallExecution):
             return (self.interface != other.interface) or (self.source != other.source)
         return False
 
+    # The __lt__ method implements a multi-level sorting logic to ensure a
+    # deterministic total order for ZoneExpression objects. This is essential for
+    # generating firewall rules in a consistent sequence, which helps in debugging
+    # and maintaining predictable firewall behavior.
+    # The sorting criteria are applied in the following order of precedence:
+    # 1. Global Status: Global zones are considered "less than" non-global zones.
+    # 2. Source Presence: Expressions with a source are "less than" those without
+    #    (maintaining original fwsimple behavior for this primary key).
+    # 3. Source Network Size: If both have sources, the one with fewer IP addresses
+    #    is "less than".
+    # 4. Interface Name (Secondary Sort):
+    #    - None interfaces come before actual interface names.
+    #    - Interface names are compared lexicographically.
+    # 5. String Representation of Source (Tertiary Sort): If all previous criteria
+    #    are equal (e.g., both have sources with the same network size, and identical
+    #    interfaces), their string representations (e.g., "1.2.3.0/24") are compared
+    #    lexicographically.
+    # This comprehensive comparison aims to ensure that for any two distinct
+    # ZoneExpression objects `a` and `b`, exactly one of `a < b` or `b < a` is
+    # true, unless they are deemed equal by all criteria (in which case `a < b`
+    # and `b < a` are both false).
     def __lt__(self, other: object) -> bool:
-        """Check if I should be smaller than the other"""
+        """Check if I should be smaller than the other for deterministic sorting."""
         if not isinstance(other, ZoneExpression):
+            return NotImplemented
+
+        # Criterion 1: Global vs Non-Global
+        # Global zones come before non-global zones.
+        is_self_global = self._zone.name == constants.GLOBAL_ZONE_NAME
+        is_other_global = other._zone.name == constants.GLOBAL_ZONE_NAME
+
+        if is_self_global != is_other_global:
+            return is_self_global  # True if self is global and other is not, False otherwise.
+
+        # At this point, either both are global or both are non-global.
+        # They are "equal" based on global status.
+
+        # Criterion 2: Source presence (maintaining original logic: "source" < "no source")
+        # This means an expression with a source is considered "smaller" than one without.
+        if self.source and not other.source:
+            return True
+        if not self.source and other.source:
             return False
 
-        if self._zone.name == constants.GLOBAL_ZONE_NAME:
-            return True
-        if other._zone.name == constants.GLOBAL_ZONE_NAME:
-            return False
+        # At this point, either both have sources or both lack sources.
+        # They are "equal" based on source presence.
+
+        # Criterion 3: Network size (if both have sources)
+        # Smaller number of addresses comes before larger.
         if self.source and other.source:
-            ### Check if the other has more addresses than I do
-            return self.source.num_addresses < other.source.num_addresses
-        if self.source:
-            ### Other has no definition, so we are smaller!
+            # This check implies self.source and other.source are not None
+            if self.source.num_addresses != other.source.num_addresses:
+                return self.source.num_addresses < other.source.num_addresses
+
+        # At this point, if both had sources, their num_addresses are the same.
+        # Or, both lack sources.
+        # They are "equal" based on network size.
+
+        # Criterion 4: Interface comparison (Secondary sort)
+        # None interface comes before string interface.
+        # Lexicographical for string interfaces.
+        if self.interface is None and other.interface is not None:
             return True
+        if self.interface is not None and other.interface is None:
+            return False
+
+        if self.interface is not None and other.interface is not None:
+            if self.interface != other.interface:
+                return self.interface < other.interface
+
+        # At this point, interfaces are "equal" (both None or same string).
+
+        # Criterion 5: Source string representation (Tertiary sort)
+        # This applies if both have sources (and same num_addresses, same interface)
+        # or if both lack sources (and same interface).
+        # str(None) is "None", so this handles None sources consistently if we were to use it.
+        # However, source presence is primary. This is for disambiguating otherwise-equal sources.
+
+        if self.source and other.source:
+            # Both sources are present, num_addresses are same, interfaces are same.
+            # Compare their string representations.
+            s_str_self = str(self.source)
+            s_str_other = str(other.source)
+            if s_str_self != s_str_other:
+                return s_str_self < s_str_other
+        # If one source is None and the other isn't, primary criterion 2 handled it.
+        # If both sources are None, they are equal by this criterion.
+
+        # If all criteria are equal, then self is not strictly less than other.
         return False
 
     # def __le__(self, other) -> bool:


### PR DESCRIPTION
Analysis of the iptables engine revealed two areas where the generated command sequence could be non-deterministic:

1. Sorting of ZoneExpression objects: The previous `__lt__` method for ZoneExpressions did not guarantee a total order in all cases. Specifically, when primary sorting keys (global status, source specificity, network size) were equivalent, the relative order of expressions could vary between runs. This was addressed by refining `ZoneExpression.__lt__` to include interface name and string representation of the source network as secondary and tertiary sorting criteria.

2. Iteration order for traffic directions: Several places in the engine code iterated over the `constants.DIRECTION` dictionary's keys to process traffic directions ('in', 'out', 'forward'). Dictionary key iteration order is not guaranteed to be consistent across all Python versions or implementations. This was addressed by introducing an `ORDERED_DIRECTIONS` list in `constants.py` and using it for iteration in `BaseEngine` and the `iptables` engine, ensuring a fixed processing order for directions.

These changes make the generation of iptables rules fully predictable, ensuring that the same configuration always produces the same set of iptables commands in the same order. Code comments have been added to explain these changes.